### PR TITLE
Add random seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@
 *.exe
 *.out
 *.app
+QBL
+
+# Vim swap files
+*.swp
+*.swo

--- a/QBL.cpp
+++ b/QBL.cpp
@@ -36,6 +36,7 @@ private:
   emp::vector<String> sample_tags;    // Include at least one question with each of these tags.
   emp::vector<String> question_files;
   size_t generate_count = 0;          // How many questions should be generated? (0 = use all)
+  int random_seed = -1;               // Random seed for generating questions (-1 = use time)
 
   // Helper functions
   void _AddTags(emp::vector<String> & tags, const String & arg) { emp::Append(tags, arg.Slice()); }
@@ -60,6 +61,8 @@ public:
       "Set output to be QBL format.");
     flags.AddOption('r', "--require", [this](String arg){ _AddTags(require_tags, arg); },
       "Only questions with the following tag(s) can be included.");
+    flags.AddOption('R', "--random", [this](String arg){ SetRandomSeed(arg); },
+      "Set the random seed");
     flags.AddOption('s', "--sample",  [this](String arg){ _AddTags(sample_tags, arg); },
       "At least one question with the following tag(s) should be included.");
 //    flags.AddOption('S', "--set",     [this](){},
@@ -110,6 +113,11 @@ public:
     }
     generate_count = _count.As<size_t>();
   }
+  
+  void SetRandomSeed(String _seed) {
+    random_seed = _seed.As<int>();
+    std::cout << "Using random seed: " << random_seed << std::endl;
+  }
 
   void PrintVersion() const {
     std::cout << "QBL (Question Bank Language) version " QBL_VERSION << std::endl;
@@ -151,7 +159,8 @@ public:
   void Generate() {
     qbank.Validate();
     if (generate_count) {
-      qbank.Generate(generate_count, include_tags, exclude_tags, require_tags, sample_tags);
+      qbank.Generate(generate_count, include_tags, exclude_tags, 
+          require_tags, sample_tags, random_seed);
     }
   }
 

--- a/QuestionBank.hpp
+++ b/QuestionBank.hpp
@@ -200,8 +200,8 @@ public:
 
   void Generate(size_t count, const tag_set_t & include_tags,
                 const tag_set_t & exclude_tags, const tag_set_t & require_tags,
-                const tag_set_t & sample_tags) {
-    emp::Random random;
+                const tag_set_t & sample_tags, int random_seed=-1) {
+    emp::Random random(random_seed);
     Generate(count, random, include_tags, exclude_tags, require_tags, sample_tags);
   }
 


### PR DESCRIPTION
If we want to perfectly regenerate a quiz, we need to be able to specify a random seed to use. 
This PR adds this view command line args to `-R` or `--random`.