### PR TITLE
Add option to output Gradescope questions that take up less space

### DIFF
--- a/QBL.cpp
+++ b/QBL.cpp
@@ -49,6 +49,7 @@ private:
   emp::vector<String> avoid_files;    // Files with lists of questions IDs to avoid
   size_t generate_count = 0;          // How many questions should be generated? (0 = use all)
   emp::Random random;                 // Random number generator
+  bool compressed_format = false;     // Should GradeScope output be compressed?
 
   // Helper functions
   void _AddTags(emp::vector<String> & tags, const String & arg, size_t count=1) {
@@ -88,6 +89,8 @@ public:
       "Set output to HTML/CSS/JS format.");
     flags.AddOption('O', "--order",   [this](String arg){ SetOrder(arg); },
       "Set the question order based on [arg] (\"random\", \"id\", or \"alpha\")");
+    flags.AddOption('c', "--compressed",   [this](){ compressed_format = true; },
+      "Make questions take less space (only works for GradeScope output).");
 
     flags.AddGroup("Question Specification",
       "These options provide addition constraints as QBL decides which questions\n"
@@ -240,7 +243,7 @@ public:
       case Format::QBL:        qbank.Print(os); break;
       case Format::NONE:       qbank.Print(os); break;
       case Format::D2L:        qbank.PrintD2L(os); break;
-      case Format::GRADESCOPE: qbank.PrintGradeScope(os); break;
+      case Format::GRADESCOPE: qbank.PrintGradeScope(os, compressed_format); break;
       case Format::LATEX:      qbank.PrintLatex(os); break;
       case Format::WEB:        emp::notify::Error("Web output must go to files."); break;
       case Format::DEBUG:      PrintDebug(os); break;

--- a/Question.hpp
+++ b/Question.hpp
@@ -176,7 +176,7 @@ public:
 
   virtual void Print(std::ostream & os=std::cout) const = 0;
   virtual void PrintD2L(std::ostream & os=std::cout) const = 0;
-  virtual void PrintGradeScope(std::ostream & os=std::cout, size_t q_num=0) const = 0;
+  virtual void PrintGradeScope(std::ostream & os=std::cout, size_t q_num=0, bool compressed=false) const = 0;
   virtual void PrintHTML(std::ostream & os=std::cout, size_t q_num=0) const = 0;
   virtual void PrintJS(std::ostream & os=std::cout) const = 0;
   virtual void PrintLatex(std::ostream & os=std::cout) const = 0;

--- a/QuestionBank.hpp
+++ b/QuestionBank.hpp
@@ -322,9 +322,9 @@ public:
     }
   }
 
-  void PrintGradeScope(std::ostream & os=std::cout) const {
+  void PrintGradeScope(std::ostream & os=std::cout, bool compressed = false) const {
     for (size_t id = 0; id < questions.size(); ++id) {
-      questions[id]->PrintGradeScope(os, id+1);
+      questions[id]->PrintGradeScope(os, id+1, compressed);
     }
   }
 

--- a/Question_MultipleChoice.cpp
+++ b/Question_MultipleChoice.cpp
@@ -32,7 +32,7 @@ void Question_MultipleChoice::PrintD2L(std::ostream& os) const {
      << ",,,,\n";
 }
 
-void Question_MultipleChoice::PrintGradeScope(std::ostream& os, size_t q_num) const {
+void Question_MultipleChoice::PrintGradeScope(std::ostream& os, size_t q_num, bool compressed) const {
   size_t opt_width = 0;
   for (size_t opt_id = 0; opt_id < options.size(); ++opt_id) {
     opt_width += 10; // Fixed amount per option.
@@ -48,6 +48,19 @@ void Question_MultipleChoice::PrintGradeScope(std::ostream& os, size_t q_num) co
     os << "\\\\\n"
        << "\\vspace{1pt}\\\\\n";
     for (size_t opt_id = 0; opt_id < options.size(); ++opt_id) {
+      os << "\\chooseone ";
+      if (options[opt_id].is_correct) os << "\\showcorrect ";
+      os << TextToLatex(options[opt_id].text) << " \\hspace*{3em}\n";
+    }
+  } else if (compressed) {
+    os << "\\\\\n";
+    int curr_width = 0;
+    for (size_t opt_id = 0; opt_id < options.size(); ++opt_id) {
+      curr_width += 10 + LineToRawText(options[opt_id].text).size();
+      if (curr_width > 100) {
+        os << "\\\\\n";
+        curr_width = 10 + LineToRawText(options[opt_id].text).size();
+      }
       os << "\\chooseone ";
       if (options[opt_id].is_correct) os << "\\showcorrect ";
       os << TextToLatex(options[opt_id].text) << " \\hspace*{3em}\n";

--- a/Question_MultipleChoice.hpp
+++ b/Question_MultipleChoice.hpp
@@ -77,7 +77,7 @@ public:
 
   void Print(std::ostream & os=std::cout) const override;
   void PrintD2L(std::ostream & os=std::cout) const override;
-  void PrintGradeScope(std::ostream & os=std::cout, size_t q_num=0) const override;
+  void PrintGradeScope(std::ostream & os=std::cout, size_t q_num=0, bool compressed = false) const override;
   void PrintHTML(std::ostream & os=std::cout, size_t q_num=0) const override;
   void PrintJS(std::ostream & os=std::cout) const override;
   void PrintLatex(std::ostream & os=std::cout) const override;

--- a/Question_ShortAnswer.cpp
+++ b/Question_ShortAnswer.cpp
@@ -27,7 +27,7 @@ void Question_ShortAnswer::PrintD2L(std::ostream& os) const {
      << ",,,,\n";
 }
 
-void Question_ShortAnswer::PrintGradeScope(std::ostream& os, size_t q_num) const {
+void Question_ShortAnswer::PrintGradeScope(std::ostream& os, size_t q_num, bool compressed) const {
   os << "NEED TO UPDATE!!!!\n";
   // os << "% QUESTION ID " << id << "\n"
   //    << "\\vspace{10pt}\n"

--- a/Question_ShortAnswer.hpp
+++ b/Question_ShortAnswer.hpp
@@ -30,7 +30,7 @@ public:
 
   void Print(std::ostream & os=std::cout) const override;
   void PrintD2L(std::ostream & os=std::cout) const override;
-  void PrintGradeScope(std::ostream & os=std::cout, size_t q_num=0) const override;
+  void PrintGradeScope(std::ostream & os=std::cout, size_t q_num=0, bool compressed = false) const override;
   void PrintHTML(std::ostream & os=std::cout, size_t q_num=0) const override;
   void PrintJS(std::ostream & os=std::cout) const override;
   void PrintLatex(std::ostream & os=std::cout) const override;

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following flags are also available:
 | `-l` or `--latex`    | (PARTIALLY IMPLEMENTED) Output to Latex format            | `-l`            |
 | `-q` or `--qbl`      | Output to QBL format.                                     | `-q`            |
 | `-w` or `--web`      | Output to HTML format.                                    | `-w`            |
+| `-c` or `--compressed`      |  Only works with Gradescope format; output questions in a compressed format that takes up less space            | `-c`            |
 
 ### Tag management
 | Flag                 | Meaning                                                   | Example                |


### PR DESCRIPTION
When trying to fit quizzes onto a single page its useful to have the option to print questions to take up less space. However, its still better to leave the default the way it is, because for long-form exams its cleaner looking. 

This pull request adds a command line flag that switches Gradescope questions to take up as little space as possiblle.