### PR TITLE
Support "check all that apply" questions for Gradescope

### DIFF
--- a/ExampleQs.qbl
+++ b/ExampleQs.qbl
@@ -3,7 +3,7 @@ Which of the following is NOT a correct way to indicate a newline at the end of 
 * `std::cout << "Hello World!" << std::endl;`
 * `std::cout << "Hello World!\n";`
 * `std::cout << "Hello World!" << "\n";`
-[*] `std::cout << "Hello World!\endl";`
+[*] `std::cout << "Hello World!\\endl";`
 * `std::cout << "Hello World!"; std::cout << "\n";`
 *+> `std::cout << "Hello World!"; std::cout << std::endl;`
 
@@ -38,3 +38,15 @@ Given the following function, which one of the following claims is incorrect? (i
 [*] If x is 10 and I call `CrazyFun(x)` it will return 100
 * if x is 5 and I call `CrazyFun(x)`, x will then be 6
 
+Which of the following numbers are even? Check all that apply
+:correct=2-4 :options=5
+* 1
+[*] 2
+* 3
+[*] 4
+* 5
+[*] 6
+* 7
+[*] 8
+* 9
+[*] 10

--- a/Question_MultipleChoice.cpp
+++ b/Question_MultipleChoice.cpp
@@ -34,6 +34,12 @@ void Question_MultipleChoice::PrintD2L(std::ostream& os) const {
 
 void Question_MultipleChoice::PrintGradeScope(std::ostream& os, size_t q_num, bool compressed) const {
   size_t opt_width = 0;
+  size_t num_correct = correct_range.GetSize();
+  std::string bubble_type = "\\chooseone ";
+  if (num_correct > 1) {
+    bubble_type = "\\choosemany ";
+  }
+  
   for (size_t opt_id = 0; opt_id < options.size(); ++opt_id) {
     opt_width += 10; // Fixed amount per option.
     opt_width += LineToRawText(options[opt_id].text).size();
@@ -48,7 +54,7 @@ void Question_MultipleChoice::PrintGradeScope(std::ostream& os, size_t q_num, bo
     os << "\\\\\n"
        << "\\vspace{1pt}\\\\\n";
     for (size_t opt_id = 0; opt_id < options.size(); ++opt_id) {
-      os << "\\chooseone ";
+      os << bubble_type;
       if (options[opt_id].is_correct) os << "\\showcorrect ";
       os << TextToLatex(options[opt_id].text) << " \\hspace*{3em}\n";
     }
@@ -61,15 +67,15 @@ void Question_MultipleChoice::PrintGradeScope(std::ostream& os, size_t q_num, bo
         os << "\\\\\n";
         curr_width = 10 + LineToRawText(options[opt_id].text).size();
       }
-      os << "\\chooseone ";
+      os << bubble_type;
       if (options[opt_id].is_correct) os << "\\showcorrect ";
-      os << TextToLatex(options[opt_id].text) << " \\hspace*{3em}\n";
+      os << TextToLatex(options[opt_id].text) << " \\hspace*{.5em}\n";
     }
   } else {
     os << "\n"
       << "\\begin{itemize}[label={}]\n";
     for (size_t opt_id = 0; opt_id < options.size(); ++opt_id) {
-      os << "\\item \\chooseone ";
+      os << "\\item " << bubble_type;
       if (options[opt_id].is_correct) os << "\\showcorrect ";
       os << TextToLatex(options[opt_id].text) << '\n';
     }


### PR DESCRIPTION
The Gradescope LaTeX template supports questions with "check all that apply" checkboxes (as opposed to radio buttons where you are supposed to just choose one) by using the `\choosemany` command in place of `\chooseone`. This pull request automatically uses `\choosemany` for questions with multiple correct answers when the format is set to Gradescope.